### PR TITLE
fix(elasticsearch): wrong yaml format in README

### DIFF
--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -695,7 +695,7 @@ sidecars:
     imagePullPolicy: Always
     ports:
       - name: portname
-       containerPort: 1234
+        containerPort: 1234
 ```
 
 Similarly, you can add extra init containers using the `initContainers` parameter.


### PR DESCRIPTION
just a readme doc invalid yaml format fix.

**Checklist**
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X] Variables are documented in the values.yaml and added to the README.md using [readme-generator-for-helm](https://github.com/bitnami-labs/readme-generator-for-helm)
- [X] Title of the PR starts with chart name (e.g. [bitnami/<name_of_the_chart>])
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/master/CONTRIBUTING.md#sign-your-work)